### PR TITLE
bug fix: change ZEC sent fee UI label to YEC

### DIFF
--- a/app/components/Transactions.js
+++ b/app/components/Transactions.js
@@ -100,7 +100,7 @@ const TxModalInternal = ({ modalIsOpen, tx, closeModal, currencyName, zecPrice, 
           {type === 'sent' && (
             <div>
               <div className={[cstyles.sublight].join(' ')}>Fees</div>
-              <div>ZEC {Utils.maxPrecisionTrimmed(fees)}</div>
+              <div>YEC {Utils.maxPrecisionTrimmed(fees)}</div>
             </div>
           )}
 


### PR DESCRIPTION
@hloo this minor change should fix the ZEC fee UI label to YEC.  This is specifically for "sent" transaction details.

Closes #4 